### PR TITLE
Allow passing in nixpkgs and macos sdk

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-import ./top.nix {
-  nixpkgs = import <nixpkgs> { };
-}
+{ nixpkgs ? import <nixpkgs> { }, macos_sdk ? null }:
+
+import ./top.nix { inherit nixpkgs macos_sdk; }

--- a/macos/default.nix
+++ b/macos/default.nix
@@ -3,7 +3,7 @@
 # binutils.  So clang and binutils recipes could be shared by the
 # different platforms we targets.
 
-{ native }:
+{ native, macos_sdk }:
 let
   nixpkgs = native.nixpkgs;
 
@@ -142,7 +142,7 @@ let
   sdk = native.make_derivation rec {
     name = "macos-sdk";
     builder = ./sdk_builder.sh;
-    src = ./MacOSX.sdk.tar.xz;
+    src = if macos_sdk != null then macos_sdk else ./MacOSX.sdk.tar.xz;
     native_inputs = [ nixpkgs.ruby ];
   } // {
     version = builtins.readFile "${sdk}/version.txt";

--- a/top.nix
+++ b/top.nix
@@ -1,4 +1,4 @@
-{ nixpkgs }:
+{ nixpkgs, macos_sdk }:
 
 rec {
   inherit nixpkgs;
@@ -17,7 +17,7 @@ rec {
       arch = "armv6";
       gcc_options = "--with-fpu=vfp --with-float=hard ";
     };
-    macos = import ./macos { inherit native; };
+    macos = import ./macos { inherit native macos_sdk; };
   };
 
   pkgFun = crossenv: import ./pkgs.nix { inherit crossenv; } // crossenv;
@@ -81,7 +81,7 @@ rec {
 
   # gcroots is a derivation that builds a list of the items that we usually do
   # not want to garbage collect.
-  gcroots_func = env: env.default_native_inputs ++ [env.qt];	
+  gcroots_func = env: env.default_native_inputs ++ [env.qt];
   gcroots = native.make_derivation rec {
     name = "gcroots.txt";
     builder = ./file_builder.sh;


### PR DESCRIPTION
This allows people to more easily use the upstream nixcrpkgs if they
wish by fetching the macos sdk separately (such as from a private s3
bucket), and then passing it as an argument to nixcrpkgs.

For good measure, this also makes it possible to pass in 'nixpkgs' so
that people who are using this from nix can avoid an extra nixpkgs
evaluation.

I retained the previous macos_sdk behavior by default, so this should be a backwards compatible change.