### PR TITLE
macos/sdk_builder: use plist, not json file

### DIFF
--- a/macos/default.nix
+++ b/macos/default.nix
@@ -143,7 +143,7 @@ let
     name = "macos-sdk";
     builder = ./sdk_builder.sh;
     src = if macos_sdk != null then macos_sdk else ./MacOSX.sdk.tar.xz;
-    native_inputs = [ nixpkgs.ruby ];
+    native_inputs = [ nixpkgs.xmlstarlet ];
   } // {
     version = builtins.readFile "${sdk}/version.txt";
   };

--- a/macos/ranlib_builder.sh
+++ b/macos/ranlib_builder.sh
@@ -42,4 +42,3 @@ eval "gcc $CFLAGS -DRANLIB ../misc/libtool.c *.o $LDFLAGS -o $host-ranlib"
 
 mkdir -p $out/bin
 cp $host-libtool $host-ranlib $out/bin/
-

--- a/macos/sdk_builder.sh
+++ b/macos/sdk_builder.sh
@@ -1,12 +1,6 @@
 source $setup
 
-tar -xf $src
-mv MacOSX*.sdk $out
+mkdir -p $out
+tar -C $out --strip-components 1 -xf $src
 
-cd $out
-ruby -rjson \
-  -e "print JSON.load(File.read('SDKSettings.json')).fetch('Version')" \
-  > version.txt
-
-# Make sure the STL headers are in the expected place.
-ls usr/include/c++/iterator > /dev/null
+xmlstarlet sel -t -v "/plist/dict/key[.='Version']/following-sibling::string[1]" "${out}/SDKSettings.plist" > $out/version.txt


### PR DESCRIPTION
Not all macos SDKs seem to bundle SDKSettings.json. Some only seem to
have SDKSettings.plist.

Parsing the plist file without ruby is pretty easy, so it seems
straightforward to switch over to that.

In addition, I removed the `ls` check at the end because it didn't seem
to be correct for the SDK I'm using.

Specifically, with my 10.10 sdk, the path seemed to be
'/usr/include/c++/v1/iterator' (note the v1).

However, since everything still worked without the check as best I can
tell, it seems reasonable to just drop it entirely.