### PR TITLE
honor NIX_BUILD_CORES when build environment

### DIFF
--- a/pretend_stdenv/setup
+++ b/pretend_stdenv/setup
@@ -1,1 +1,2 @@
 export PATH=$_PATH
+export MAKEFLAGS="-j$NIX_BUILD_CORES"


### PR DESCRIPTION
see https://nixos.org/manual/nix/unstable/advanced-topics/cores-vs-jobs.html

> It is up to the derivations' build script to respect host's requested cores-per-build by following the value of the NIX_BUILD_CORES environment variable.

this PR allow us to enable parallel build by using `nix-build -A linux64.hello --cores $(nproc)`