### PR TITLE
Add flake support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,6 @@
   description = "Tools for cross-compiling standalone applications using Nix.";
 
   outputs = { self }: {
-    lib.nixcrpkgs = import ./top.nix;
+    lib.nixcrpkgs = { nixpkgs, macos_sdk ? null }: import ./top.nix { inherit nixpkgs macos_sdk; };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "Tools for cross-compiling standalone applications using Nix.";
+
+  outputs = { self }: {
+    lib.nixcrpkgs = import ./top.nix;
+  };
+}

--- a/make_derivation.nix
+++ b/make_derivation.nix
@@ -32,7 +32,7 @@ let
   };
 
   default_attrs = {
-    system = builtins.currentSystem;
+    system = nixpkgs.system;
 
     SHELL = "${nixpkgs.bashInteractive}/bin/bash";
 


### PR DESCRIPTION
This adds a basic flake.nix for exposing nixcrpkgs as a flake

Also changed builtins.currentSystem to nixpkgs.system (which works mostly the same, as we only use nixpkgs for currentSystem)

nixpkgs has to be specified explicitly as builtins.currentSystem is no longer available in flakes