### PR TITLE
Add qt6.qt5compat

### DIFF
--- a/pkgs/qt6/default.nix
+++ b/pkgs/qt6/default.nix
@@ -143,6 +143,14 @@ let
     };
   };
 
+  qt5compat = module {
+    name = "qt5compat";
+    src = crossenv.nixpkgs.fetchzip {
+      url = "https://download.qt.io/official_releases/qt/6.4/${version}/submodules/qt5compat-everywhere-src-${version}.tar.xz";
+      hash = "sha256-kCEQHh+J7sTHQQKKynUvv/pKxyREFztN0fi7sRdzY7Q=";
+    };
+  };
+
   # Build a selection of Qt examples that help us see if the library and its
   # modules are working.
   examples = crossenv.make_derivation {
@@ -169,4 +177,4 @@ let
       else "";
   };
 in
-  base // { inherit qt_host qtserialport examples; }
+  base // { inherit qt_host qtserialport qt5compat examples; }


### PR DESCRIPTION
Hi all,

I'm not very experienced with C compiler toolchains, but this has been such a super helpful tool for setting up Windows cross-compilation. I'm using this to set up automated builds for a cross-platform app over at [https://github.com/unraid/usb-creator/tree/automated-builds](https://github.com/unraid/usb-creator/tree/automated-builds).

One of the issues I encountered is that the app I'm working on pulls in quazip, which requires QT::Core5Compat. 

I went and implemented Core5Compat compilation with your intuitive module system, and this PR is meant to upstream this module tooling that I'm using.

On a related note, I also looked into adding a Quazip package to this project, and I did get it to compile for windows with these cmake flags:
```
-DBUILD_SHARED_LIBS=OFF  -DQUAZIP_FETCH_LIBS=OFF -DQUAZIP_BZIP2=OFF
```
 (building a DLL ran into zlib conflicts)
But I had massive issues with zlib when trying to compile the final app, which seems to be a common problem with static QT apps that use zlib.